### PR TITLE
fixed examples in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ b.Command("buy", func(ctx *ctx.Context) error {
         return nil
     }
 
-    return ctx.Invoice("Premium Access", "Get premium features", "premium_123", "XTR").
+    return ctx.SendInvoice("Premium Access", "Get premium features", "premium_123", "XTR").
         Price("Premium Plan", 100).  // 100 stars
         Protect().                   // Content protection
         Send().Err()
@@ -586,7 +586,7 @@ Show typing indicators and other actions:
 ```go
 b.On.Message.Text(func(ctx *ctx.Context) error {
     // Show typing indicator
-    ctx.ChatAction().Typing().Send()
+    ctx.SendChatAction().Typing().Send()
 
     // Process message...
     time.Sleep(2 * time.Second)


### PR DESCRIPTION
Hi! 
I really like your framework. We're currently experimenting with it and want to use it in our projects. However, when copying the examples, the code sometimes didn't work because you seemed to have renamed the functions. I've included the corrections into readme examples. 

With best regards, Nikita R